### PR TITLE
Fix: Add option "root": true to ESLint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  root: true,
   env: {
     commonjs: true,
     es6: true,


### PR DESCRIPTION
Added option `root: true` to ESLint config. By default, ESLint will look for configuration files in all parent folders up to the root directory and it causes problems for some students (yes, I know, it's `core-js-numbers` on screenshot below. But this task also needs this option in the config)

![image](https://github.com/rolling-scopes-school/core-js-strings/assets/3116682/83a9f7c0-7bd0-46aa-8a88-760baddf3986)
