### PR TITLE
Fix typo in return typing in isPalindrome subtask

### DIFF
--- a/src/strings-tasks.js
+++ b/src/strings-tasks.js
@@ -297,7 +297,7 @@ function countVowels(/* str */) {
  * https://en.wikipedia.org/wiki/Palindrome
  *
  * @param {string} str - The input string.
- * @return {bool} - True if the string is a palindrome, false otherwise.
+ * @return {boolean} - True if the string is a palindrome, false otherwise.
  *
  * @example:
  *   isPalindrome('madam') => true


### PR DESCRIPTION
Docstring for isPalindrome subtask describes return typing as `{bool}`, but `{boolean}` should be instead.
<img width="980" alt="image" src="https://github.com/user-attachments/assets/33000b18-1f1b-4275-aebe-a3df49519e88">
